### PR TITLE
Ensure game iframe resizes after load

### DIFF
--- a/content/themes/default/js/script.js
+++ b/content/themes/default/js/script.js
@@ -174,11 +174,15 @@ function open_fullscreen() {
 	}
 };
 var can_resize = false;
-if($('iframe#game-area').length){
-	can_resize = true;
-	resize_game_iframe();
-	load_leaderboard({type: 'top', amount: 10});
-}
+$(window).on('load', function () {
+        const iframe = $('iframe#game-area');
+        if (iframe.length) {
+                can_resize = true;
+                resize_game_iframe();
+                iframe.on('load', resize_game_iframe);
+                load_leaderboard({type: 'top', amount: 10});
+        }
+});
 function resize_game_iframe(){
 	if(can_resize){
 		let iframe = $("iframe.game-iframe");


### PR DESCRIPTION
## Summary
- Only initialize game iframe resizing after the page fully loads
- Re-trigger resize when the iframe contents finish loading

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check content/themes/default/js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68b3dc3f6a4083249e9db871ba4f3088